### PR TITLE
Automatically enable access for assistive devices using osascript

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class slate {
   }
 
   exec { "enable assistive devices":
-    command => "echo -n 'a' | tee /private/var/db/.AccessibilityAPIEnabled > /dev/null 2>&1; chmod 444 /private/var/db/.AccessibilityAPIEnabled",
+    command => "osascript -e 'tell application \"System Events\" to set UI elements enabled to true'",
     onlyif => "[ ! -f /private/var/db/.AccessibilityAPIEnabled ]",
     user => root,
     require => Package['slate']


### PR DESCRIPTION
I love slate, spectacle and all the different window managers, but in order to use them you need to manually go in and enable assistive devices.

This little addition just turns on assistive device support if it hasn't been turned on already. Any chance it could get added in?
